### PR TITLE
fix: Fixed command to check for OpenShift CLI

### DIFF
--- a/iam-webhook-s3-example.sh
+++ b/iam-webhook-s3-example.sh
@@ -70,7 +70,7 @@ set -- "${POSITIONAL[@]}"
 command -v aws >/dev/null 2>&1 || { echo >&2 "AWS CLI is required but not installed.  Aborting."; exit 1; } 
 
 # Check if oc cli tool is installed
-command -v aws >/dev/null 2>&1 || { echo >&2 "AWS CLI is required but not installed.  Aborting."; exit 1; } 
+command -v oc >/dev/null 2>&1 || { echo >&2 "OpenShift CLI is required but not installed.  Aborting."; exit 1; }
 
 # Check if jq tool is installed
 command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but not installed.  Aborting."; exit 1; } 


### PR DESCRIPTION
Command to check for the AWS CLI was duplicated and was used where
command to check for OpenShift CLI should be.

Fixes #1